### PR TITLE
Reblocks API change requires now 4-arguments for initiateFormAction

### DIFF
--- a/src/providers/email/processing.lisp
+++ b/src/providers/email/processing.lisp
@@ -132,7 +132,7 @@
                                        (uiop:ensure-list
                                         (form-css-classes widget)))
                         :submit-fn (if *recaptcha-site-key*
-                                       "submitFormWithRecaptcha(\"~A\", $(this))"
+                                       "return submitFormWithRecaptcha(\"~A\", event, this)"
                                        *js-default-form-action*))
          (when *recaptcha-site-key*
            (:script :src (format nil "https://www.google.com/recaptcha/api.js?render=~A"
@@ -140,13 +140,17 @@
 
            (:script
             (:raw (format nil "
-      function submitFormWithRecaptcha(actionCode, form) {
+      function submitFormWithRecaptcha(actionCode, event, form) {
+        if (event && typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
         grecaptcha.ready(function() {
           grecaptcha.execute('~A', {action: 'submit'}).then(function(token) {
               var options = {'args': {'recaptcha-token': token}};
-              initiateFormAction(actionCode, form, options);
+              initiateFormAction(actionCode, event, form, options);
           });
         });
+        return false;
       }
 "
                           *recaptcha-site-key*))))


### PR DESCRIPTION
This is related to [ultralisp/ultralisp #314 ](https://github.com/ultralisp/ultralisp/issues/314)

The Reblocks API change that required the 4-argument initiateFormAction call is was introduced and is documented in Reblocks PR #57: https://github.com/40ants/reblocks/pull/57

This PR introduced changes to the initiateFormAction JavaScript function that required updating the function signature from 3 arguments to 4 arguments, where the fourth argument is an options object.

The current fix in reblocks-auth was specifically implemented to accommodate this breaking change in Reblocks core framework.