### PR TITLE
Now function REBLOCKS-AUTH/CORE:RENDER-BUTTONS accepts current-page's…

### DIFF
--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -15,6 +15,14 @@
                               "HMAC-SHA256"
                               "reCAPTCHA"
                               "HTTP"))
+  (0.16.0 2026-03-21
+          "
+Backward incompatible changes
+=============================
+
+Now function REBLOCKS-AUTH/CORE:RENDER-BUTTONS accepts current-page's path as a RETPATH argument by default.
+Usually this is what you expect - to return to the same page after the login.
+")
   (0.15.1 2026-03-15
           "
 Fixed

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -8,6 +8,7 @@
   (:import-from #:reblocks/response
                 #:redirect)
   (:import-from #:reblocks/request
+                #:get-path
                 #:get-parameters
                 #:get-parameter)
   (:import-from #:reblocks/widget
@@ -79,7 +80,7 @@
     (log:debug "Goal" goal-name "was reached")))
 
 
-(defun render-buttons (&key retpath)
+(defun render-buttons (&key (retpath (get-path)))
   "Renders a row of buttons for enabled service providers.
 
    Optionally you can specify RETPATH argument with an URI to return user


### PR DESCRIPTION
… path as a RETPATH argument by default.

Usually this is what you expect - to return to the same page after the login.